### PR TITLE
docs: fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@
 -->
 
 - 🔭 I’m currently working with C++ for building high quality generic firmware
-- 🌱 I’m currently playing with NFC and Zephyr for building contacless solutions
+- 🌱 I’m currently playing with NFC and Zephyr for building contactless solutions
 - 👯 I’m looking to collaborate on firmware projects
 - 💬 Ask me anything about IoT solutions and connecting devices to the cloud
 - 📫 How to reach me: you can reach me from the social media links above


### PR DESCRIPTION
## Summary
- fix contactless typo in README

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68963aca49f88323948b978294100608